### PR TITLE
Fix for Pluto notebooks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024 Richard Reeve 
+Copyright (c) 2024-2025 Richard Reeve 
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # NEWS
 
+- v0.1.5
+  - Can't add license info for Pluto notebooks
 - v0.1.4
   - More compatibility fixes
 - v0.1.3

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "ResearchSoftwareMetadata"
 uuid = "58378933-4625-47fa-851e-05ee27d397bd"
 license = "BSD-2-Clause"
 authors = ["Richard Reeve <richard.reeve@glasgow.ac.uk>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/codemeta.json
+++ b/codemeta.json
@@ -14,10 +14,10 @@
         "Linux",
         "macOS"
     ],
-    "version": "v0.1.4",
-    "dateModified": "2024-10-16",
+    "version": "v0.1.5",
+    "dateModified": "2025-04-02",
     "datePublished": "2024-07-18",
-    "downloadUrl": "https://github.com/boydorr/ResearchSoftwareMetadata.jl/archive/refs/tags/v0.1.4.tar.gz",
+    "downloadUrl": "https://github.com/boydorr/ResearchSoftwareMetadata.jl/archive/refs/tags/v0.1.5.tar.gz",
     "license": "https://spdx.org/licenses/BSD-2-Clause",
     "author": [
         {

--- a/src/ResearchSoftwareMetadata.jl
+++ b/src/ResearchSoftwareMetadata.jl
@@ -637,7 +637,7 @@ function crosswalk(git_dir = readchomp(`$(Git.git()) rev-parse --show-toplevel`)
                     data = readlines(jl_file)
                     if startswith(data[1], "# SPDX-License-Identifier:")
                         data[1] = "# SPDX-License-Identifier: $(project["license"])"
-                    else
+                    elseif !startswith(data[1], "### A Pluto.jl notebook ###")
                         pushfirst!(data, "")
                         pushfirst!(data,
                                    "# SPDX-License-Identifier: $(project["license"])")


### PR DESCRIPTION
- Don't add license info to Pluto notebooks as it breaks Pluto's recognition of files.